### PR TITLE
Enhance bid generation with format-aware outline workflow

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/src/outline_builder.py
+++ b/src/outline_builder.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Utilities for building bid document outlines and generating full text."""
+
+from typing import List
+
+from llm_client import LLMClient as Client
+from .caching import LLMCache, llm_rewrite
+from .requirements_parser import RequirementItem, FormatRequirement
+
+
+def build_outline(format_reqs: List[FormatRequirement], content_reqs: List[RequirementItem]) -> str:
+    """Generate a bid document outline.
+
+    Each format requirement becomes a top-level section. Content requirements
+    assigned to the same section are listed beneath it.
+    """
+
+    lines: List[str] = []
+    for fmt in format_reqs:
+        lines.append(f"# {fmt.section}")
+        if fmt.details:
+            lines.append(fmt.details)
+        for item in content_reqs:
+            if item.section == fmt.section:
+                detail = f": {item.notes}" if item.notes else ""
+                lines.append(f"- {item.title}{detail}")
+        lines.append("")
+    return "\n".join(lines).strip()
+
+
+def generate_bid(outline: str, *, client: Client, cache: LLMCache, use_llm: bool = True) -> str:
+    """Generate the final bid document text from an outline using LLM."""
+
+    if not use_llm:
+        return outline
+    system = (
+        "You are an expert bid writer. Based on the provided outline, write a complete "
+        "bid document in Markdown."
+    )
+    user = f"Outline:\n{outline}\nWrite the bid document."
+    return llm_rewrite(client, system, user, cache)

--- a/tests/test_outline_builder.py
+++ b/tests/test_outline_builder.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from src.requirements_parser import RequirementItem, parse_format_requirements
+from src.outline_builder import build_outline, generate_bid
+from src.caching import LLMCache
+
+
+class DummyClient:
+    def chat(self, messages, temperature=None, max_tokens=None):
+        user = messages[1]["content"]
+        if user.startswith("Outline:"):
+            return "BID"
+        return '[{"id": "1", "section": "封面", "details": "A4纸"}]'
+
+
+def test_parse_format_and_generate(tmp_path: Path):
+    fmt_file = tmp_path / "fmt.txt"
+    fmt_file.write_text("format text", encoding="utf-8")
+    client = DummyClient()
+    cache = LLMCache(tmp_path / "cache")
+
+    format_reqs = parse_format_requirements(fmt_file, client=client, cache=cache, use_llm=True)
+    assert format_reqs[0].section == "封面"
+
+    content = [RequirementItem(id="1", title="项目概述", keywords=[], source="", notes="简要介绍", weight=1.0, section="封面")]
+    outline = build_outline(format_reqs, content)
+    assert "项目概述" in outline
+    assert "A4纸" in outline
+
+    bid = generate_bid(outline, client=client, cache=cache, use_llm=True)
+    assert bid == "BID"


### PR DESCRIPTION
## Summary
- extend requirement parsing to include document sections and extract format specifications
- add outline builder to group content by format sections and drive LLM bid generation
- cover new workflow with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a67c057b74832a9342e0b0a11d17ef