### PR TITLE
docs: add pipeline overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 
 本项目是一个面向各类招投标场景的智能化标书生成系统，能够根据招标文件自动解析需求、检索资料并生成规范的投标响应文档。
 系统以大语言模型（LLM）为核心，结合知识库检索与 LaTeX 排版，实现从需求提取到 PDF 输出的完整流程。
+
+## 构建管线
+
+1. **加载配置与模板** — [build_pdf.py](build_pdf.py)
+2. **解析需求** — [src/requirements_parser.py](src/requirements_parser.py)
+3. **扫描知识库并检索相关内容** — [src/kb_search.py](src/kb_search.py)
+4. **合并生成 Markdown** — [src/content_merge.py](src/content_merge.py)
+5. **Markdown 转 LaTeX** — [src/latex_renderer.py](src/latex_renderer.py)
+6. **渲染模板并编译 PDF** — [src/pdf_builder.py](src/pdf_builder.py)
+7. **表格抽取（可选）** — [src/table_extractor.py](src/table_extractor.py)
+
 ## 项目特色
 
 -  **智能驱动**：基于LLM（大语言模型）的智能内容生成
@@ -29,7 +40,8 @@
 │   ├── content_merge.py           # 内容合并
 │   ├── latex_renderer.py          # LaTeX渲染器
 │   ├── caching.py                 # 缓存管理
-│   └── logging_utils.py           # 日志工具
+│   ├── logging_utils.py           # 日志工具
+│   └── table_extractor.py         # PDF表格提取工具
 │
 ├── 📁 scripts/                    # 脚本工具目录
 │   ├── pdf_extractor.py           # PDF内容提取
@@ -100,6 +112,7 @@
 - **PDF生成**：自动生成符合要求的投标文件
 - **分页布局**：每条需求自动分页呈现，避免内容过于紧凑
 - **需求分类**：LLM区分需生成文字与需原文复制的条目
+- **表格识别**：从招标PDF提取表格并转换为LaTeX
 
 ### 2. 技术方案设计
 - **系统架构**：分层架构设计，支持扩展
@@ -156,7 +169,7 @@ export DASHSCOPE_API_KEY="your-api-key-here"
 
 1. **生成投标文件**
 ```bash
-python build_pdf.py --requirements test_requirements.md --kb litchi-smart-orchard-bid --out bid_document.pdf
+python build_pdf.py --requirements test_requirements.md --kb litchi-smart-orchard-bid --out bid_document.pdf --config pyproject.toml
 ```
 
 2. **提取文档内容**
@@ -179,7 +192,12 @@ python -m pytest tests/
 - 修改 `config.py` 中的参数
 - 调整温度和最大token数
 
-3. **扩展知识库**
+3. **配置项目信息**
+- 在 `pyproject.toml` 的 `[tool.build_pdf.project]` 中设置 `project_no`、`bid_date` 等字段
+- 或者在命令中通过 `--config custom.toml` 指定其他配置文件
+- `bid_date` 支持 `YYYY年MM月`、`YYYY-MM-DD` 等多种输入格式，程序会统一标准化
+
+4. **扩展知识库**
 - 在 `litchi-smart-orchard-bid/` 目录添加文档
 - 更新文档结构和内容
 
@@ -191,7 +209,7 @@ python -m pytest tests/
 python scripts/simple_pdf_generator.py
 
 # 使用LLM生成器
-python build_pdf.py --requirements test_requirements.md --kb litchi-smart-orchard-bid --out test_bid.pdf --topk 3
+python build_pdf.py --requirements test_requirements.md --kb litchi-smart-orchard-bid --out test_bid.pdf --topk 3 --config pyproject.toml
 ```
 
 ### 示例2：端到端运行（先提取需求再生成PDF）

--- a/src/table_extractor.py
+++ b/src/table_extractor.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Utilities for extracting tables from PDFs and rendering them."""
+
+from pathlib import Path
+from typing import List
+
+import pdfplumber
+
+
+def extract_tables(path: Path) -> List[List[List[str]]]:
+    """Extract tables from a PDF.
+
+    Returns a list of tables, where each table is represented as a list of
+    rows and each row is a list of cell strings.
+    """
+    tables: List[List[List[str]]] = []
+    with pdfplumber.open(path) as pdf:
+        for page in pdf.pages:
+            for table in page.extract_tables():
+                # Normalize cells to strings and strip whitespace
+                normalized = [[(cell or "").strip() for cell in row] for row in table]
+                tables.append(normalized)
+    return tables
+
+
+def table_to_markdown(table: List[List[str]]) -> str:
+    """Convert a table (list of rows) to Markdown format."""
+    if not table:
+        return ""
+    header = table[0]
+    md_lines = ["| " + " | ".join(header) + " |"]
+    md_lines.append("|" + "|".join(["---"] * len(header)) + "|")
+    for row in table[1:]:
+        md_lines.append("| " + " | ".join(row) + " |")
+    return "\n".join(md_lines)
+
+
+def table_to_latex(table: List[List[str]]) -> str:
+    """Convert a table (list of rows) to a LaTeX tabular environment."""
+    if not table:
+        return ""
+    cols = max(len(row) for row in table)
+    col_spec = " | ".join(["l"] * cols)
+    lines = [r"\begin{tabular}{" + col_spec + "}", r"\hline"]
+    for row in table:
+        cells = [escape_latex(cell) for cell in row]
+        lines.append(" & ".join(cells) + r" \\")
+        lines.append(r"\hline")
+    lines.append(r"\end{tabular}")
+    return "\n".join(lines)
+
+
+def escape_latex(text: str) -> str:
+    """Escape special LaTeX characters in ``text``."""
+    replacements = {
+        "&": r"\&",
+        "%": r"\%",
+        "$": r"\$",
+        "#": r"\#",
+        "_": r"\_",
+        "{": r"\{",
+        "}": r"\}",
+        "~": r"\textasciitilde{}",
+        "^": r"\textasciicircum{}",
+        "\\": r"\textbackslash{}",
+    }
+    for k, v in replacements.items():
+        text = text.replace(k, v)
+    return text
+
+
+def extract_tables_to_latex(path: Path) -> List[str]:
+    """Convenience wrapper returning LaTeX tables from ``path``."""
+    return [table_to_latex(t) for t in extract_tables(path)]

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -1,0 +1,40 @@
+import os
+import pytest
+
+from src.pdf_builder import apply_project_config, format_bid_date, load_config
+
+
+def test_format_bid_date_variants():
+    assert format_bid_date("2023-12-01") == "2023年12月01日"
+    assert format_bid_date("2023/12/01") == "2023年12月01日"
+    assert format_bid_date("2023年12月1日") == "2023年12月01日"
+    assert format_bid_date("2023年12月") == "2023年12月"
+
+
+def test_apply_project_config_sets_env(monkeypatch):
+    monkeypatch.delenv("PROJECT_NO", raising=False)
+    monkeypatch.delenv("BID_DATE", raising=False)
+    cfg = {"project_no": "ABC123", "bid_date": "2024-02-03", "bid_title": "示例"}
+    apply_project_config(cfg)
+    assert os.getenv("PROJECT_NO") == "ABC123"
+    assert os.getenv("BID_DATE") == "2024年02月03日"
+    assert os.getenv("BID_TITLE") == "示例"
+
+
+def test_apply_project_config_missing(monkeypatch):
+    with pytest.raises(ValueError):
+        apply_project_config({"project_no": "ONLY"})
+
+
+def test_load_config_from_path(tmp_path):
+    cfg_path = tmp_path / "custom.toml"
+    cfg_path.write_text(
+        """
+        [tool.build_pdf.project]
+        project_no = "X-1"
+        bid_date = "2025-01-02"
+        """,
+        encoding="utf-8",
+    )
+    cfg = load_config(cfg_path)
+    assert cfg["project"]["project_no"] == "X-1"

--- a/tests/test_table_extractor.py
+++ b/tests/test_table_extractor.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from pathlib import Path
+from src.table_extractor import extract_tables, table_to_markdown, table_to_latex
+from src.latex_renderer import markdown_to_latex
+from src.caching import LLMCache
+
+
+class DummyClient:
+    def chat(self, messages, temperature=None, max_tokens=None):
+        return "LaTeX"
+
+
+def test_table_extraction_and_render(monkeypatch, tmp_path):
+    class DummyPage:
+        def extract_tables(self):
+            return [[["H1", "H2"], ["C1", "C2"]]]
+
+    class DummyPDF:
+        pages = [DummyPage()]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def mock_open(path):
+        return DummyPDF()
+
+    monkeypatch.setattr("src.table_extractor.pdfplumber.open", mock_open)
+
+    tables = extract_tables(Path("dummy.pdf"))
+    assert tables == [[['H1', 'H2'], ['C1', 'C2']]]
+
+    md = table_to_markdown(tables[0])
+    cache = LLMCache(tmp_path / "cache")
+    latex = markdown_to_latex(md, client=DummyClient(), cache=cache, use_llm=False)
+    assert "\\begin{tabular}" in latex
+    assert "H1" in latex and "C2" in latex
+
+    latex_direct = table_to_latex(tables[0])
+    assert "\\begin{tabular}" in latex_direct
+    assert "H1" in latex_direct


### PR DESCRIPTION
## Summary
- document build pipeline in README with links to implementation files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a808eb3170832aaa611ac1b8b992ee