### PR TITLE
feat: write requirement files

### DIFF
--- a/full_pipeline.py
+++ b/full_pipeline.py
@@ -232,7 +232,15 @@ def main() -> None:
     # 步骤5: 大纲撰写与内容生成
     progress.start_step("内容生成", "先撰写大纲，再分段生成并直接拼接内容")
     try:
-        merged_md, meta = merge_contents(requirements, ranked, client=client, cache=cache, use_llm=True)
+        req_dir = workdir / "requirements"
+        merged_md, meta = merge_contents(
+            requirements,
+            ranked,
+            client=client,
+            cache=cache,
+            use_llm=True,
+            output_dir=req_dir,
+        )
         md_path = workdir / "merged.md"
         md_path.write_text(merged_md, encoding="utf-8")
 

--- a/src/pdf_builder.py
+++ b/src/pdf_builder.py
@@ -173,7 +173,15 @@ def build_pdf(
     # 步骤4: 生成内容
     print("📝 步骤4/5: 生成内容...")
     with tqdm(total=1, desc="生成内容", unit="文档") as pbar:
-        merged_md, meta = merge_contents(requirements_items, ranked, client=client, cache=cache, use_llm=True)
+        req_dir = workdir / "requirements"
+        merged_md, meta = merge_contents(
+            requirements_items,
+            ranked,
+            client=client,
+            cache=cache,
+            use_llm=True,
+            output_dir=req_dir,
+        )
         merged_md_path = workdir / "merged.md"
         merged_md_path.write_text(merged_md, encoding="utf-8")
         pbar.update(1)


### PR DESCRIPTION
## Summary
- allow `merge_contents` to save each requirement's response as its own Markdown file via new `output_dir` option
- generate those per-requirement files in both `pdf_builder` and `full_pipeline` workflows

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad132ccf80832ab9460a38ce7b408c