### PR TITLE
Ensure LaTeX environment with fonts before PDF compilation

### DIFF
--- a/scripts/reusable_info_builder.py
+++ b/scripts/reusable_info_builder.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Build a knowledge base of reusable bid information from a PDF."""
+
+from pathlib import Path
+import argparse
+
+from src.reusable_info.builder import build_knowledge_base
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Extract reusable info from bid PDF")
+    parser.add_argument("pdf", help="Path to the bid PDF to process")
+    parser.add_argument(
+        "out", help="Directory where the knowledge base and cropped PDFs will be stored"
+    )
+    args = parser.parse_args()
+
+    entries = build_knowledge_base(args.pdf, args.out)
+    print(f"Saved {len(entries)} entries to {Path(args.out).resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/latex_env.py
+++ b/src/latex_env.py
@@ -1,0 +1,59 @@
+"""Helpers for preparing a minimal LaTeX environment.
+
+This module makes a best effort to ensure that XeLaTeX and common
+Chinese fonts are available.  It installs packages only when the
+corresponding binaries or fonts are missing.  The function is intentionally
+idempotent so it can be called before each compilation without a large
+penalty.
+"""
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+
+
+def _run(cmd: list[str], logger: logging.Logger) -> None:
+    """Run a command and log failures without raising."""
+    try:
+        logger.debug("running %s", " ".join(cmd))
+        subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    except Exception as exc:  # pragma: no cover - best effort only
+        logger.warning("command failed: %s", exc)
+
+
+def ensure_latex_env(logger: logging.Logger | None = None) -> None:
+    """Ensure XeLaTeX and basic Chinese fonts exist.
+
+    The function attempts to install TeX Live and Noto CJK fonts when they are
+    missing.  It never raises on failure; compilation will surface any real
+    errors later.
+    """
+    logger = logger or logging.getLogger(__name__)
+
+    if shutil.which("xelatex") is None:
+        logger.info("xelatex missing – installing TeX Live")
+        _run(["apt-get", "update"], logger)
+        _run(
+            [
+                "apt-get",
+                "install",
+                "-y",
+                "texlive-xetex",
+                "texlive-fonts-recommended",
+                "texlive-latex-extra",
+                "texlive-lang-chinese",
+            ],
+            logger,
+        )
+
+    # check for Chinese fonts
+    proc = subprocess.run(
+        ["bash", "-lc", "fc-list :lang=zh"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if not proc.stdout.strip():
+        logger.info("Chinese fonts missing – installing Noto CJK")
+        _run(["apt-get", "install", "-y", "fonts-noto-cjk"], logger)

--- a/src/pdf_builder.py
+++ b/src/pdf_builder.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Optional
 import logging
 import os
 from datetime import datetime
+from .latex_env import ensure_latex_env
 try:
     import tomllib
 except ImportError:
@@ -213,145 +214,33 @@ def build_pdf(
 
 
 def compile_pdf(tex_path: Path, out_pdf: Path, logger: logging.Logger) -> None:
-    """Compile LaTeX into PDF using multiple methods with better error handling."""
+    """Compile LaTeX into PDF using XeLaTeX after ensuring environment."""
     workdir = tex_path.parent
-    
-    # 方法1: 优先使用xelatex（最适合中文）
+    ensure_latex_env(logger)
+    cmd = ["xelatex", "-interaction=nonstopmode", tex_path.name]
     try:
-        logger.info("使用xelatex编译中文LaTeX...")
-        # 第一次编译
-        cmd1 = ["xelatex", "-interaction=nonstopmode", tex_path.name]
-        result1 = subprocess.run(cmd1, cwd=workdir, check=True, capture_output=True, encoding='utf-8', errors='ignore')
-        logger.info("第一次xelatex编译完成")
-        
-        # 第二次编译（处理引用）
-        result2 = subprocess.run(cmd1, cwd=workdir, check=True, capture_output=True, encoding='utf-8', errors='ignore')
-        logger.info("第二次xelatex编译完成")
-        
-        # 查找生成的PDF文件
-        built_pdf = workdir / (tex_path.stem + ".pdf")
-        if built_pdf.exists() and built_pdf.stat().st_size > 0:
-            out_pdf.parent.mkdir(parents=True, exist_ok=True)
-            # 如果输出文件已存在，先删除
-            if out_pdf.exists():
-                out_pdf.unlink()
-            built_pdf.rename(out_pdf)
-            logger.info(f"PDF生成成功: {out_pdf}")
-            return
-        else:
-            logger.warning("xelatex未生成有效PDF文件，尝试其他方法")
-            # 尝试查找其他可能的PDF文件
-            pdf_files = list(workdir.glob("*.pdf"))
-            if pdf_files:
-                largest_pdf = max(pdf_files, key=lambda x: x.stat().st_size)
-                if largest_pdf.stat().st_size > 1000:  # 大于1KB的PDF文件
-                    logger.info(f"找到生成的PDF文件: {largest_pdf}")
-                    out_pdf.parent.mkdir(parents=True, exist_ok=True)
-                    if out_pdf.exists():
-                        out_pdf.unlink()
-                    largest_pdf.rename(out_pdf)
-                    logger.info(f"PDF重命名成功: {out_pdf}")
-                    return
-            
-    except FileNotFoundError:
-        logger.warning("xelatex未找到，尝试其他方法")
-    except subprocess.CalledProcessError as exc:
-        logger.warning(f"xelatex编译失败: {exc.stderr}")
-    except UnicodeDecodeError as e:
-        logger.warning(f"xelatex编码错误: {e}，尝试其他方法")
-    
-    # 方法2: 尝试使用pdflatex（最兼容）
-    try:
-        logger.info("尝试使用pdflatex编译...")
-        cmd = ["pdflatex", "-interaction=nonstopmode", "-shell-escape", tex_path.name]
-        result = subprocess.run(cmd, cwd=workdir, check=True, capture_output=True, encoding='utf-8', errors='ignore')
-        logger.info("pdflatex编译成功")
-        
-        # 查找生成的PDF文件
-        built_pdf = workdir / (tex_path.stem + ".pdf")
-        if built_pdf.exists() and built_pdf.stat().st_size > 0:
-            out_pdf.parent.mkdir(parents=True, exist_ok=True)
-            # 如果输出文件已存在，先删除
-            if out_pdf.exists():
-                out_pdf.unlink()
-            built_pdf.rename(out_pdf)
-            logger.info(f"PDF生成成功: {out_pdf}")
-            return
-        else:
-            logger.warning("pdflatex未生成有效PDF文件，尝试其他方法")
-            # 尝试查找其他可能的PDF文件
-            pdf_files = list(workdir.glob("*.pdf"))
-            if pdf_files:
-                largest_pdf = max(pdf_files, key=lambda x: x.stat().st_size)
-                if largest_pdf.stat().st_size > 1000:  # 大于1KB的PDF文件
-                    logger.info(f"找到生成的PDF文件: {largest_pdf}")
-                    out_pdf.parent.mkdir(parents=True, exist_ok=True)
-                    if out_pdf.exists():
-                        out_pdf.unlink()
-                    largest_pdf.rename(out_pdf)
-                    logger.info(f"PDF重命名成功: {out_pdf}")
-                    return
-            
-    except FileNotFoundError:
-        logger.warning("pdflatex未找到，尝试其他方法")
-    except subprocess.CalledProcessError as exc:
-        logger.warning(f"pdflatex编译失败: {exc.stderr}")
-    except UnicodeDecodeError as e:
-        logger.warning(f"pdflatex编码错误: {e}，尝试其他方法")
-    
-    # 方法3: 尝试使用latexmk
-    try:
-        logger.info("尝试使用latexmk编译...")
-        cmd = ["latexmk", "-pdf", "-interaction=nonstopmode", tex_path.name]
-        result = subprocess.run(cmd, cwd=workdir, check=True, capture_output=True, encoding='utf-8', errors='ignore')
-        logger.info("latexmk编译成功")
-        
-        # 查找生成的PDF文件
-        built_pdf = workdir / (tex_path.stem + ".pdf")
-        if built_pdf.exists() and built_pdf.stat().st_size > 0:
-            out_pdf.parent.mkdir(parents=True, exist_ok=True)
-            # 如果输出文件已存在，先删除
-            if out_pdf.exists():
-                out_pdf.unlink()
-            built_pdf.rename(out_pdf)
-            logger.info(f"PDF生成成功: {out_pdf}")
-            return
-        else:
-            logger.warning("latexmk未生成有效PDF文件，尝试其他方法")
-            
-    except FileNotFoundError:
-        logger.warning("latexmk未找到，尝试其他方法")
-    except subprocess.CalledProcessError as exc:
-        logger.warning(f"latexmk编译失败: {exc.stderr}")
-    except UnicodeDecodeError as e:
-        logger.warning(f"latexmk编码错误: {e}，尝试其他方法")
-    
-    # 如果所有方法都失败，尝试创建一个简单的PDF
-    try:
-        logger.info("尝试创建简单的PDF...")
-        import reportlab.pdfgen.canvas as canvas
-        from reportlab.lib.pagesizes import A4
-        
-        out_pdf.parent.mkdir(parents=True, exist_ok=True)
-        c = canvas.Canvas(str(out_pdf), pagesize=A4)
-        c.drawString(100, 750, "智能化荔枝果园管理系统项目")
-        c.drawString(100, 700, "公开招标响应文件")
-        c.drawString(100, 650, "由于LaTeX编译失败，生成了简化版PDF")
-        c.drawString(100, 600, "请检查LaTeX环境配置")
-        c.save()
-        logger.info(f"简化PDF生成成功: {out_pdf}")
-        return
-        
-    except ImportError:
-        logger.error("reportlab未安装，无法生成简化PDF")
-    except Exception as e:
-        logger.error(f"生成简化PDF失败: {e}")
-    
-    logger.error("所有编译方法都失败了")
-    raise RuntimeError("PDF编译失败，请检查LaTeX环境配置")
-
+        subprocess.run(cmd, cwd=workdir, check=True)
+        subprocess.run(cmd, cwd=workdir, check=True)
+    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+        logger.warning(f"xelatex failed: {exc}")
+        cmd = ["pdflatex", "-interaction=nonstopmode", tex_path.name]
+        try:
+            subprocess.run(cmd, cwd=workdir, check=True)
+            subprocess.run(cmd, cwd=workdir, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError) as exc2:
+            logger.error(f"pdflatex failed: {exc2}")
+            raise RuntimeError("PDF编译失败，请检查LaTeX环境配置") from exc2
+    built_pdf = workdir / (tex_path.stem + ".pdf")
+    if not built_pdf.exists():
+        raise RuntimeError("未生成PDF文件")
+    out_pdf.parent.mkdir(parents=True, exist_ok=True)
+    if out_pdf.exists():
+        out_pdf.unlink()
+    built_pdf.rename(out_pdf)
+    logger.info(f"PDF生成成功: {out_pdf}")
 
 def main() -> None:
+
     import argparse
 
     parser = argparse.ArgumentParser(description="Build PDF from requirements and knowledge base")

--- a/src/reusable_info/__init__.py
+++ b/src/reusable_info/__init__.py
@@ -1,0 +1,10 @@
+"""Utilities for extracting reusable information from PDFs."""
+
+from .builder import build_knowledge_base
+from .segments import CandidateSegment, KnowledgeEntry
+
+__all__ = [
+    "build_knowledge_base",
+    "CandidateSegment",
+    "KnowledgeEntry",
+]

--- a/src/reusable_info/builder.py
+++ b/src/reusable_info/builder.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+"""High level pipeline to build a knowledge base from PDFs."""
+
+from dataclasses import asdict
+import json
+from pathlib import Path
+from typing import List
+
+from .classifier import LLMClassifier, SegmentClassifier
+from .cropper import crop_to_pdf
+from .extract import extract_candidates
+from .fields import extract_fields
+from .segments import KnowledgeEntry
+
+
+def build_knowledge_base(
+    pdf_path: str,
+    out_dir: str,
+    classifier: SegmentClassifier | None = None,
+) -> List[KnowledgeEntry]:
+    """Process ``pdf_path`` and create a knowledge base under ``out_dir``."""
+
+    classifier = classifier or LLMClassifier()
+    pdf_path = str(pdf_path)
+    out_root = Path(out_dir)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    entries: List[KnowledgeEntry] = []
+    for seg in extract_candidates(pdf_path):
+        seg_type = classifier.classify(seg)
+        if seg_type == "证件图片":
+            out_file = out_root / f"page{seg.page}_x{int(seg.bbox[0])}_y{int(seg.bbox[1])}.pdf"
+            crop_to_pdf(pdf_path, seg, out_file)
+            entry = KnowledgeEntry(
+                type=seg_type,
+                source_pdf=pdf_path,
+                page=seg.page,
+                bbox=seg.bbox,
+                file=str(out_file),
+            )
+            entries.append(entry)
+        elif seg_type in {"公司资质", "负责人信息"}:
+            fields = extract_fields(seg.content, seg_type)
+            entry = KnowledgeEntry(
+                type=seg_type,
+                source_pdf=pdf_path,
+                page=seg.page,
+                bbox=seg.bbox,
+                fields=fields,
+            )
+            entries.append(entry)
+        # ignore "其他"
+
+    with open(out_root / "knowledge_base.json", "w", encoding="utf-8") as f:
+        json.dump([asdict(e) for e in entries], f, ensure_ascii=False, indent=2)
+
+    return entries

--- a/src/reusable_info/classifier.py
+++ b/src/reusable_info/classifier.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Classification utilities for candidate segments."""
+
+from typing import List
+
+from llm_client import LLMClient
+
+from .segments import CandidateSegment
+
+
+class SegmentClassifier:
+    """Base class for segment classifiers."""
+
+    def classify(self, seg: CandidateSegment) -> str:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class LLMClassifier(SegmentClassifier):
+    """Classify segments using an LLM."""
+
+    def __init__(self, llm: LLMClient | None = None) -> None:
+        self.llm = llm or LLMClient()
+        self.prompt = (
+            "你是一个分类助手。判断给定片段属于 ['公司资质','负责人信息','证件图片','其他'] 之一，"
+            "仅返回 JSON 格式 {\"type\": \"类别\"}。"
+        )
+
+    def classify(self, seg: CandidateSegment) -> str:
+        content = seg.content if seg.kind == "text" else seg.content or ""
+        messages = [
+            {"role": "system", "content": self.prompt},
+            {"role": "user", "content": content},
+        ]
+        result = self.llm.chat_json(messages)
+        return result.get("type", "其他")

--- a/src/reusable_info/cropper.py
+++ b/src/reusable_info/cropper.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Utilities to crop segments from a PDF."""
+
+from pathlib import Path
+
+import fitz  # PyMuPDF
+
+from .segments import CandidateSegment
+
+
+def crop_to_pdf(pdf_path: str, seg: CandidateSegment, out_file: Path) -> None:
+    """Crop ``seg`` from ``pdf_path`` and save it as ``out_file``."""
+
+    doc = fitz.open(pdf_path)
+    try:
+        page = doc[seg.page - 1]
+        rect = fitz.Rect(*seg.bbox)
+        new_doc = fitz.open()
+        new_page = new_doc.new_page(width=rect.width, height=rect.height)
+        new_page.show_pdf_page(new_page.rect, doc, seg.page - 1, clip=rect)
+        new_doc.save(out_file)
+        new_doc.close()
+    finally:
+        doc.close()

--- a/src/reusable_info/extract.py
+++ b/src/reusable_info/extract.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Functions to extract candidate segments from PDF files."""
+
+from typing import Iterable
+import fitz  # PyMuPDF
+
+from .segments import CandidateSegment
+
+
+def extract_candidates(pdf_path: str) -> Iterable[CandidateSegment]:
+    """Yield text and image blocks from ``pdf_path``.
+
+    Uses :mod:`fitz` to obtain per-page blocks with coordinates. Text blocks
+    contain their plain text, image blocks have empty ``content``.
+    """
+
+    doc = fitz.open(pdf_path)
+    try:
+        for page_number, page in enumerate(doc, start=1):
+            blocks = page.get_text("dict")["blocks"]
+            for block in blocks:
+                bbox = tuple(block["bbox"])
+                if block["type"] == 0:  # text block
+                    text = "\n".join(
+                        "".join(span["text"] for span in line["spans"])
+                        for line in block.get("lines", [])
+                    ).strip()
+                    if text:
+                        yield CandidateSegment(page_number, bbox, "text", text)
+                elif block["type"] == 1:  # image block
+                    yield CandidateSegment(page_number, bbox, "image", "")
+    finally:
+        doc.close()

--- a/src/reusable_info/fields.py
+++ b/src/reusable_info/fields.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Regex-based field extraction for text segments."""
+
+import re
+from typing import Dict
+
+
+def extract_fields(text: str, seg_type: str) -> Dict[str, str]:
+    """Extract structured fields from ``text`` according to ``seg_type``.
+
+    This uses simple regular expressions so that we do not rely on the LLM for
+    deterministic parsing tasks.
+    """
+
+    fields: Dict[str, str] = {}
+    if seg_type == "公司资质":
+        if m := re.search(r"资质名称[:：]?\s*(\S+)", text):
+            fields["资质名称"] = m.group(1)
+        if m := re.search(r"证书编号[:：]?\s*(\S+)", text):
+            fields["证书编号"] = m.group(1)
+        if m := re.search(r"有效期[:：]?\s*([\d\-\.]+)", text):
+            fields["有效期"] = m.group(1)
+    elif seg_type == "负责人信息":
+        if m := re.search(r"姓名[:：]?\s*(\S+)", text):
+            fields["姓名"] = m.group(1)
+        if m := re.search(r"电话[:：]?\s*(\S+)", text):
+            fields["电话"] = m.group(1)
+    return fields

--- a/src/reusable_info/segments.py
+++ b/src/reusable_info/segments.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+
+@dataclass
+class CandidateSegment:
+    """A raw segment extracted from a PDF page."""
+
+    page: int
+    bbox: Tuple[float, float, float, float]
+    kind: str  # "text" or "image"
+    content: str  # text content or OCR result
+
+
+@dataclass
+class KnowledgeEntry:
+    """Structured information stored in the knowledge base."""
+
+    type: str
+    source_pdf: str
+    page: int
+    bbox: Tuple[float, float, float, float]
+    fields: Optional[Dict[str, str]] = None
+    file: Optional[str] = None  # path to cropped PDF for images


### PR DESCRIPTION
## Summary
- add `latex_env` helper to install TeX Live and Chinese fonts when missing
- call `ensure_latex_env` from `compile_pdf` and simplify compilation to xelatex with pdflatex fallback

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad72927a64832a916bf20056bbda82