### PR TITLE
Switch templates to Noto CJK fonts

### DIFF
--- a/templates/main.tex
+++ b/templates/main.tex
@@ -1,4 +1,6 @@
-\documentclass[UTF8,a4paper,zihao=-4]{ctexart}
+\documentclass[UTF8,a4paper,zihao=-4,fontset=none]{ctexart}
+\setCJKfamilyfont{song}{Noto Serif CJK SC}
+\setCJKfamilyfont{hei}{Noto Sans CJK SC}
 \usepackage{geometry}
 \usepackage{graphicx}
 \usepackage{xcolor}

--- a/templates/main_chinese_simple.tex
+++ b/templates/main_chinese_simple.tex
@@ -1,5 +1,6 @@
-\documentclass[a4paper,12pt]{article}
-\usepackage[utf8]{inputenc}
+\documentclass[UTF8,a4paper,12pt,fontset=none]{ctexart}
+\setCJKfamilyfont{song}{Noto Serif CJK SC}
+\setCJKfamilyfont{hei}{Noto Sans CJK SC}
 \usepackage{geometry}
 \usepackage{graphicx}
 \usepackage{hyperref}
@@ -7,12 +8,6 @@
 \usepackage{listings}
 \usepackage{amsmath}
 \usepackage{amssymb}
-\usepackage{xeCJK}
-
-% 设置中文字体
-\setCJKmainfont{SimSun}
-\setCJKsansfont{SimHei}
-\setCJKmonofont{FangSong}
 
 % 页面设置
 \geometry{

--- a/templates/main_compatible.tex
+++ b/templates/main_compatible.tex
@@ -1,5 +1,7 @@
 \documentclass[UTF8,a4paper,12pt]{article}
-\usepackage[UTF8]{ctex}
+\usepackage[UTF8,fontset=none]{ctex}
+\setCJKfamilyfont{song}{Noto Serif CJK SC}
+\setCJKfamilyfont{hei}{Noto Sans CJK SC}
 \usepackage{geometry}
 \usepackage{graphicx}
 \usepackage{xcolor}


### PR DESCRIPTION
## Summary
- Specify `fontset=none` in Chinese LaTeX templates
- Map `song` and `hei` families to Noto fonts

## Testing
- `pytest` *(fails: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_68aeb1608188832a9f6225e15387e522