### PR TITLE
check latex dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@
 ### 部署要求
 - **操作系统**：Windows/macOS/Linux
 - **Python环境**：Python 3.8+
-- **TeX发行版**：支持XeLaTeX
+- **TeX发行版**：支持XeLaTeX，并安装 Noto CJK 字体
 - **内存要求**：建议8GB以上
 
 ## 快速开始
@@ -160,10 +160,15 @@ pip install -r requirements.txt
 export DASHSCOPE_API_KEY="your-api-key-here"
 ```
 
-3. **安装TeX发行版**
+3. **安装TeX发行版和 Noto CJK 字体**
 - Windows: 安装MiKTeX或TeX Live
 - macOS: 安装MacTeX
-- Linux: 安装TeX Live
+- Linux: 安装TeX Live 并安装中文字体
+  ```bash
+  sudo apt-get update && sudo apt-get install -y \
+      texlive-xetex texlive-latex-recommended texlive-fonts-recommended \
+      texlive-lang-chinese fonts-noto-cjk
+  ```
 
 ### 基本使用
 

--- a/src/latex_env.py
+++ b/src/latex_env.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+
+def ensure_latex_env(logger: logging.Logger) -> None:
+    """Verify XeLaTeX and Noto CJK fonts are available.
+
+    Raises
+    ------
+    RuntimeError
+        If XeLaTeX or Noto CJK fonts are missing.
+    """
+    if shutil.which("xelatex") is None:
+        raise RuntimeError(
+            "XeLaTeX not found. Please install TeX Live with xelatex support."
+        )
+
+    try:
+        result = subprocess.run(
+            ["fc-list", "Noto Sans CJK"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "fontconfig utility 'fc-list' is required to verify fonts. "
+            "Please install fonts-noto-cjk and fontconfig."
+        ) from exc
+
+    if not result.stdout.strip():
+        raise RuntimeError(
+            "Noto Sans CJK fonts not found. Please install fonts-noto-cjk."
+        )
+
+    logger.info("XeLaTeX and Noto fonts detected")

--- a/src/pdf_builder.py
+++ b/src/pdf_builder.py
@@ -33,6 +33,7 @@ from .requirements_parser import parse_requirements
 from .kb_search import scan_kb, rank_files
 from .content_merge import merge_contents
 from .latex_renderer import markdown_to_latex, render_main_tex
+from .latex_env import ensure_latex_env
 
 
 # 尝试使用兼容的模板，避免字体问题
@@ -122,44 +123,6 @@ def apply_project_config(project: Dict[str, str]) -> None:
                 val = format_bid_date(val)
             os.environ[env] = val
 
-
-def ensure_latex_env(logger: logging.Logger) -> None:
-    """Ensure XeLaTeX and Chinese fonts are available.
-
-    Some environments lack the LaTeX toolchain or CJK fonts which causes
-    errors like ``mktexpk: don't know how to create bitmap font for
-    unihei6c``.  This helper tries to install a minimal set of packages at
-    runtime so that PDF compilation has a better chance of succeeding.  The
-    installation is best-effort and failures are only logged.
-    """
-
-    try:
-        subprocess.run(["xelatex", "--version"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        return  # xelatex already present
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        logger.info("xelatex not found; attempting to install TeX Live and fonts...")
-
-    try:
-        subprocess.run(["apt-get", "update"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        subprocess.run(
-            [
-                "apt-get",
-                "install",
-                "-y",
-                "texlive-xetex",
-                "texlive-latex-recommended",
-                "texlive-fonts-recommended",
-                "texlive-lang-chinese",
-                "fonts-noto-cjk",
-            ],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        subprocess.run(["fc-cache", "-fv"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        logger.info("LaTeX environment with Chinese fonts installed")
-    except Exception as exc:  # pragma: no cover - install is best effort
-        logger.warning("Failed to install LaTeX dependencies: %s", exc)
 
 
 def build_pdf(


### PR DESCRIPTION
## Summary
- replace runtime apt-get installs with a new `ensure_latex_env` that checks for XeLaTeX and Noto fonts
- document TeX Live and `fonts-noto-cjk` installation steps in README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aeb161a190832aabfede91138d6fc7