### PR TITLE
refactor: centralize API key in LLM client

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - **Python**：`>=3.10`
 - **依赖安装**：`pip install -r requirements.txt`
 - **LaTeX 环境**：需预先安装 `xelatex`、`pdflatex` 或 `latexmk`（任一即可）。
-- **通义千问 API Key**：在环境变量 `DASHSCOPE_API_KEY` 中指定；未设置时会使用 `llm_client.py` 中的默认测试密钥。
+- **通义千问 API Key**：由 `llm_client.py` 内置管理，无需额外配置环境变量。
 
 建议在虚拟环境中运行：
 ```bash
@@ -133,7 +133,7 @@ export BID_DATE=2024-06-30
 ```
 
 ## 7. 常见问题
-1. **API Key 无效或超额**：确认 `DASHSCOPE_API_KEY` 正确且配额充足。
+1. **API Key 无效或超额**：请确认 `llm_client.py` 中配置的密钥仍可使用并且配额充足。
 2. **LaTeX 编译失败**：请确保系统已安装完整的 LaTeX 工具链，并在日志中查看具体错误；程序会在 `build/` 目录留下 `main.tex` 供调试。
 3. **知识库未找到内容**：检查 `--kb` 路径是否正确，或知识库文件是否为空。
 4. **中文乱码**：确保运行环境和 LaTeX 模板均为 UTF‑8 编码，必要时安装中文字体。

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -17,12 +17,9 @@ python3 --version
 pip install -r requirements.txt
 ```
 
-### 3. 配置API密钥
-```bash
-export DASHSCOPE_API_KEY="your-api-key-here"
-```
+> 项目已在 `llm_client.py` 中内置示例 API 密钥，如需更换可直接修改该文件。
 
-### 4. 安装LaTeX（可选）
+### 3. 安装LaTeX（可选）
 - **macOS**: `brew install --cask mactex`
 - **Ubuntu**: `sudo apt-get install texlive-full`
 - **Windows**: 下载安装MiKTeX
@@ -76,15 +73,6 @@ python build_pdf.py --requirements test_requirements.md --kb litchi-smart-orchar
 ```
 
 ## 常见问题解决
-
-### ❌ API密钥错误
-```bash
-# 检查环境变量
-echo $DASHSCOPE_API_KEY
-
-# 重新设置
-export DASHSCOPE_API_KEY="your-actual-key"
-```
 
 ### ❌ LaTeX编译失败
 ```bash

--- a/full_pipeline.py
+++ b/full_pipeline.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import time
 from pathlib import Path
 import logging
@@ -155,7 +154,7 @@ def main() -> None:
     config = load_config()
     temperature = config.get("temperature")
     client = Client(models=None, temperature=temperature if temperature is not None else 0.2)
-    api = QianwenAPI(os.getenv("DASHSCOPE_API_KEY", ""))
+    api = QianwenAPI()
 
     # 步骤1: 提取需求（可选）
     if args.skip_extract:

--- a/litchi-smart-orchard-bid/scripts/README.md
+++ b/litchi-smart-orchard-bid/scripts/README.md
@@ -33,10 +33,8 @@ pip install pandas openpyxl
 
 ## 配置说明
 
-### 1. 设置环境变量（推荐）
-```bash
-export DASHSCOPE_API_KEY='你的dashscope密钥'
-```
+### 1. 配置API密钥
+项目默认在 `llm_client.py` 中内置示例密钥，如需更换请直接修改该文件。
 
 ### 2. 可选：修改配置文件 (config.py)
 如需自定义路径或参数，可在 `config.py` 中调整。
@@ -148,7 +146,7 @@ python enhanced_requirement_scorer.py
 ```
 错误: API密钥格式不正确，应该以'sk-'开头
 ```
-**解决方案**：检查是否已通过环境变量 `DASHSCOPE_API_KEY` 正确设置
+**解决方案**：检查 `llm_client.py` 中的 `DEFAULT_API_KEY` 是否设置正确
 
 #### 2. 文件路径不存在
 ```

--- a/litchi-smart-orchard-bid/scripts/README_scoring.md
+++ b/litchi-smart-orchard-bid/scripts/README_scoring.md
@@ -28,10 +28,7 @@ scripts/
 ## 配置说明
 
 ### 1. API配置
-在运行前设置环境变量，并在 `scoring_config.py` 中自动读取：
-```bash
-export DASHSCOPE_API_KEY='你的dashscope密钥'
-```
+项目使用 `llm_client.py` 中预置的API密钥，如需更换请在该文件中修改 `DEFAULT_API_KEY`。
 
 ### 2. 路径配置
 ```python

--- a/litchi-smart-orchard-bid/scripts/dashscope_client.py
+++ b/litchi-smart-orchard-bid/scripts/dashscope_client.py
@@ -12,22 +12,23 @@ import time
 from typing import List, Dict, Any, Optional
 import logging
 
+from llm_client import LLMClient
+
 # 配置日志
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class DashScopeClient:
     """通义千问API客户端"""
-    
+
     def __init__(self):
-        self.api_key = os.getenv('DASHSCOPE_API_KEY')
-        if not self.api_key:
-            raise ValueError("环境变量DASHSCOPE_API_KEY未设置")
-        
+        llm = LLMClient()
+        self.api_key = llm.api_key
+
         self.base_url = "https://dashscope.aliyuncs.com/api/v1"
         self.embedding_model = os.getenv('QW_EMBEDDING_MODEL', 'text-embedding-v1')
         self.llm_model = os.getenv('QW_MODEL_NAME', 'qwen-plus')
-        
+
         self.headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json"

--- a/litchi-smart-orchard-bid/scripts/intelligent_scorer.py
+++ b/litchi-smart-orchard-bid/scripts/intelligent_scorer.py
@@ -578,8 +578,8 @@ class IntelligentScorer:
 def main():
     """主函数"""
     # API密钥配置
-    import os
-    api_key = os.getenv("DASHSCOPE_API_KEY", "")
+    from llm_client import LLMClient
+    api_key = LLMClient().api_key
     
     # 项目根目录
     library_root = "/Users/leojiang/PycharmProjects/标书生成/litchi-smart-orchard-bid"

--- a/litchi-smart-orchard-bid/scripts/requirement_scorer.py
+++ b/litchi-smart-orchard-bid/scripts/requirement_scorer.py
@@ -514,8 +514,8 @@ class RequirementScorer:
 def main():
     """主函数"""
     # API密钥配置
-    import os
-    api_key = os.getenv("DASHSCOPE_API_KEY", "")
+    from llm_client import LLMClient
+    api_key = LLMClient().api_key
     
     # 项目根目录
     project_root = "/Users/leojiang/PycharmProjects/标书生成/litchi-smart-orchard-bid"

--- a/litchi-smart-orchard-bid/scripts/run_bid_generator.py
+++ b/litchi-smart-orchard-bid/scripts/run_bid_generator.py
@@ -4,11 +4,11 @@
 标书生成主运行脚本
 """
 
-import os
 import sys
 import json
 import argparse
 import logging
+import os
 from pathlib import Path
 
 # 添加当前目录到Python路径
@@ -76,9 +76,10 @@ def main():
     
     try:
         # 检查环境变量
-        if not os.getenv('DASHSCOPE_API_KEY'):
-            logger.error("环境变量DASHSCOPE_API_KEY未设置")
-            logger.info("请设置通义千问API密钥：export DASHSCOPE_API_KEY='你的dashscope密钥'")
+        from llm_client import LLMClient
+        if not LLMClient().api_key:
+            logger.error("未配置API密钥")
+            logger.info("请在 llm_client.py 中设置有效的通义千问API密钥")
             return 1
         
         # 初始化标书生成器

--- a/litchi-smart-orchard-bid/scripts/scoring_config.py
+++ b/litchi-smart-orchard-bid/scripts/scoring_config.py
@@ -4,9 +4,9 @@
 智能评分程序配置文件
 """
 
-# 通义千问API配置（改为从环境变量读取，禁止硬编码）
-import os
-QIANWEN_API_KEY = os.getenv("DASHSCOPE_API_KEY", "")
+# 通义千问API配置
+from llm_client import LLMClient
+QIANWEN_API_KEY = LLMClient().api_key
 QIANWEN_BASE_URL = "https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation"
 
 # 多个模型配置，按优先级排序

--- a/llm_client.py
+++ b/llm_client.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import hashlib
 import json
-import os
 import time
 from typing import Dict, List, Optional
 
@@ -51,7 +50,7 @@ class LLMClient:
 
     def __post_init__(self) -> None:
         if self.api_key is None:
-            self.api_key = os.getenv("DASHSCOPE_API_KEY") or DEFAULT_API_KEY
+            self.api_key = DEFAULT_API_KEY
 
         if self.models is None:
             self.models = [

--- a/scripts/extract_required_documents.py
+++ b/scripts/extract_required_documents.py
@@ -13,7 +13,7 @@ import pdfplumber
 from datetime import datetime
 import time
 
-from llm_client import LLMClient, DEFAULT_API_KEY
+from llm_client import LLMClient
 
 class DocumentExtractor:
     def __init__(self, llm: LLMClient | None = None):
@@ -295,9 +295,8 @@ def main():
     print("🔧 招标文件文档提取器")
     print("=" * 50)
     
-    # 检查API密钥
-    api_key = os.getenv("QIANWEN_API_KEY", DEFAULT_API_KEY)
-    llm = LLMClient(api_key=api_key)
+    # 初始化LLM客户端（内部包含API密钥）
+    llm = LLMClient()
     
     # 检查PDF文件
     pdf_path = "03.招标文件.pdf"

--- a/scripts/run_extractor.bat
+++ b/scripts/run_extractor.bat
@@ -26,11 +26,6 @@ if %errorlevel% neq 0 (
     )
 )
 
-REM 检查API密钥
-if "%QIANWEN_API_KEY%"=="" (
-    set QIANWEN_API_KEY=sk-fe0485c281964259b404907d483d3777
-)
-
 REM 检查PDF文件
 if not exist "03.招标文件.pdf" (
     echo ❌ 错误：未找到招标文件PDF

--- a/scripts/run_extractor.sh
+++ b/scripts/run_extractor.sh
@@ -22,11 +22,6 @@ if ! python3 -c "import pdfplumber, requests" &> /dev/null; then
     fi
 fi
 
-# 检查API密钥
-if [ -z "$QIANWEN_API_KEY" ]; then
-    export QIANWEN_API_KEY="sk-fe0485c281964259b404907d483d3777"
-fi
-
 # 检查PDF文件
 if [ ! -f "03.招标文件.pdf" ]; then
     echo "❌ 错误：未找到招标文件PDF"


### PR DESCRIPTION
## Summary
- remove environment variable usage for API key
- initialize Qianwen/DashScope clients using `LLMClient` defaults
- update docs and helper scripts to reflect new configuration

## Testing
- `python -m py_compile llm_client.py scripts/extract_required_documents.py scripts/pdf_extractor.py full_pipeline.py litchi-smart-orchard-bid/scripts/dashscope_client.py litchi-smart-orchard-bid/scripts/intelligent_scorer.py litchi-smart-orchard-bid/scripts/requirement_scorer.py litchi-smart-orchard-bid/scripts/run_bid_generator.py litchi-smart-orchard-bid/scripts/scoring_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68afbd2eec00832aa0e75f3cd16adbb3